### PR TITLE
Fix spelling in create_batches comment

### DIFF
--- a/etc.py
+++ b/etc.py
@@ -240,7 +240,7 @@ def normalize_gradients(gradients):
     return gradients
 
 
-# Spliting a dataset into smaller chunks.
+# Splitting a dataset into smaller chunks.
 def create_batches(inputs, targets, batch_size):
     for i in range(0, len(inputs), batch_size):
         yield inputs[i:i + batch_size], targets[i:i + batch_size]


### PR DESCRIPTION
## Summary
- fix typo in comment above `create_batches`

## Testing
- `python -m py_compile etc.py`


------
https://chatgpt.com/codex/tasks/task_e_6848748cb788832083df41da4b59ab7e