### PR TITLE
Fix per-neuron bias update in backward_unstable

### DIFF
--- a/feedforward.py
+++ b/feedforward.py
@@ -201,7 +201,8 @@ class FeedForward:
                 grad_weight += l2_lambda * layer["weights"]
 
             layer["weights"] -= self.learning_rate * grad_weight
-            layer["biases"] -= self.learning_rate * delta.mean(axis=0)  # Use of mean for size compatibility
+            # Update each bias with its corresponding delta value
+            layer["biases"] -= self.learning_rate * delta
 
             # Prepares the gradient for the next layer (previous in the order of execution)
             if i > 0:


### PR DESCRIPTION
## Summary
- ensure backward_unstable adjusts each bias using its matching delta

## Testing
- `python -m py_compile feedforward.py etc.py`


------
https://chatgpt.com/codex/tasks/task_e_6848831557f883208ed1164e2576d8e4